### PR TITLE
python-evdev: add patch to make sure it uses sysroot headers

### DIFF
--- a/meta-python/recipes-devtools/python/python-evdev/use-sysroot-headers.patch
+++ b/meta-python/recipes-devtools/python/python-evdev/use-sysroot-headers.patch
@@ -1,0 +1,24 @@
+--- a/setup.py	2016-10-01 10:00:11.491758891 -0700
++++ b/setup.py	2016-10-01 10:01:45.045089476 -0700
+@@ -65,10 +65,17 @@
+ 
+ #-----------------------------------------------------------------------------
+ def create_ecodes():
+-    headers = [
+-        '/usr/include/linux/input.h',
+-        '/usr/include/linux/input-event-codes.h',
+-    ]
++
++    if not os.path.lexists(os.path.expandvars('$STAGING_INCDIR')):
++        headers = [
++            '/usr/include/linux/input.h',
++            '/usr/include/linux/input-event-codes.h',
++        ]
++    else:
++        headers = [
++            os.path.expandvars('$STAGING_INCDIR/linux/input.h'),
++            os.path.expandvars('$STAGING_INCDIR/linux/input-event-codes.h'),   
++        ]
+ 
+     headers = [header for header in headers if os.path.isfile(header)]
+     if not headers:

--- a/meta-python/recipes-devtools/python/python-evdev_0.6.0.bb
+++ b/meta-python/recipes-devtools/python/python-evdev_0.6.0.bb
@@ -4,15 +4,18 @@ SECTION = "devel/python"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=18debddbb3f52c661a129724a883a8e2"
 
+SRC_URI = "https://github.com/gvalkov/python-evdev/archive/v${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz \
+           file://use-sysroot-headers.patch \
+"
 
-SRC_URI[md5sum] = "294ac2997bd419d56b9451511536f9f4"
-SRC_URI[sha256sum] = "c0e1410cc88eaa6a016baeafb2acb1274d36a057944143b59e94f36bb4aaaa82"
+SRC_URI[md5sum] = "963ea4bc961434ee355bfea6b697a4e3"
+SRC_URI[sha256sum] = "2a65a1c2657a7d9b989bb4557ddd27fd4be85c46e26f74362fe5c46939d4c857"
 
 DEPENDS_${PN} += "\
     ${PYTHON_PN}-ctypes \
 "
 
-inherit pypi setuptools
+inherit setuptools
 
 RDEPENDS_${PN} += "\
     ${PYTHON_PN}-ctypes \
@@ -21,3 +24,11 @@ RDEPENDS_${PN} += "\
     ${PYTHON_PN}-shell \
     ${PYTHON_PN}-stringold \
 "
+
+do_install_append() {
+    # note the full docs require Sphinx to build them
+    install -d ${D}${datadir}/doc/${BPN}/
+    install -m 0644 ${S}/README.rst ${D}${datadir}/doc/${PN}/
+}
+
+PACKAGES = "${PN}-doc ${PN} ${PN}-dbg"


### PR DESCRIPTION
This currently works (randomly) when BUILD_HOST headers are a close enough match, but fails as soon as they differ, due to static header include paths in setup.py.  This patch adds a path check for the STAGING_INC dir and makes it use the right headers.  This patch breaks on 0.6.1 because of a trivial change but an updated one works fine.  I'll switch 0.6.1 back to pypi and check it.
